### PR TITLE
Update docker run command

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ docker build -t team4-app .
 
 Step 4: Run the Docker Container
 ```
-docker run -p 5004:5004 team4-app
+docker run -d -p 5004:5004 team4-app
 ```
 
 You can access the application at: http://127.0.0.1:5004/ or http://localhost:5004/


### PR DESCRIPTION
In the foreground mode, Docker can start the process in the container and attach the console to the process’s standard input, standard output, and standard error.

The disadvantage of running a container in the foreground is that you can not access the command prompt anymore, which means you can not run any other commands while the container is running.
To run a Docker container in the background, use the    -d=true    or just    -d    option. 

First, stop it from the foreground mode by pressing [Ctrl+C],  then run it in a detached mode.